### PR TITLE
Throw a TypeError instead of InvalidAccessError

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
             </li>
             <li>
               <p>If <var>delay</var> is negative, <a>throw</a> an
-              <code>InvalidAccessError</code> and abort these steps.</p>
+              <code>TypeError</code> and abort these steps.</p>
             </li>
             <li>
               <p>Set the value of <var>receiver</var>'s


### PR DESCRIPTION
InvalidAccessError is deprecated:
https://heycam.github.io/webidl/#invalidaccesserror